### PR TITLE
Document how to filter by path

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ on:
   push:
     branches:
       - master
+    # Paths can be used to only trigger actions when you have edited certain files, such as a file within the /docs directory
     paths:
       - 'docs/**.md'
       - 'docs/images/**'

--- a/README.md
+++ b/README.md
@@ -125,6 +125,9 @@ on:
   push:
     branches:
       - master
+    paths:
+      - 'docs/**.md'
+      - 'docs/images/**'
 
 jobs:
   converttopdf:


### PR DESCRIPTION
Thanks for making this great tool!

Since GitHub Actions allows [filtering by paths](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#onpushpull_requestpaths), suggesting the use of a path filter will cut down on unnecessary triggering of the job.

Only changes to the docs or images folder will trigger the job.