### PR TITLE
Unable to render HTML (thus PDF) correctly when no images are referenced in md

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@ name: 'Create PDF and HTML'
 description: 'Creates PDF and HTML files from Markdown using the GitHub (or custom) theme.'
 runs:
   using: 'docker'
-  image: 'docker://baileyjm02/markdown-to-pdf:latest'
+  image: 'Dockerfile'
 
 inputs:
   input_dir:

--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@ name: 'Create PDF and HTML'
 description: 'Creates PDF and HTML files from Markdown using the GitHub (or custom) theme.'
 runs:
   using: 'docker'
-  image: 'Dockerfile'
+  image: 'docker://baileyjm02/markdown-to-pdf:latest'
 
 inputs:
   input_dir:

--- a/markdown-to-pdf.js
+++ b/markdown-to-pdf.js
@@ -109,13 +109,13 @@ async function ConvertImageRoutes(html) {
 	while (m = rex.exec(newPaths)) {
 		try {
 			let image = await encodeImage(m[1]);
-			newPaths = newPaths.replace(new RegExp(m[1], "g"), image);
+			if (image != null) { newPaths = newPaths.replace(new RegExp(m[1], "g"), image); }
 		} catch (error) {
 			console.log('ERROR:', error);
 		}
 		encoded = newPaths
 	}
-	return encoded;
+	return (encoded == null) ? newPaths : encoded;
 }
 
 // This converts the markdown string to it's HTML values # => h1 etc.


### PR DESCRIPTION
Hey @BaileyJM02 

I discovered this bug when I was trying to convert multiple markdown files into PDFs in a project.

I have created a repository for demonstration purpose: https://github.com/bernardkkt/md2pdf

There are 4 markdown files inside the `docs` folder: `01.md`, `02.md`, `03.md` and `04.md`. All except `03.md` have the `<img>` tag. For `01.md` and `02.md`, the `<img>` tag points to a local image file, whereas for `04.md` the `<img>` tag points to an internet link. The output files in HTML and PDF for these 3 files are fine.

However, when a markdown file contains no `<img>` tags at all, which is the case in `03.md`, it will only be rendered with one word `undefined`. I have found the root cause and attempted to fix it, and if you are fine with the changes I will update this pull request after restoring the `action.yml` file.

You may refer to this [attachment](https://github.com/BaileyJM02/markdown-to-pdf/files/5358587/artifact.zip), which contains all the HTML and PDF files after running your GitHub Actions in my repository.

I am relying on a workaround to circumvent the issue, so there's no rush to include this fix if it needs more time for you to go through.

