### PR TITLE
fix: output dir is dir

### DIFF
--- a/src/github_interface.js
+++ b/src/github_interface.js
@@ -61,7 +61,7 @@ let OutputDirIsDir = false
 try {
     OutputDirIsDir = fs.lstatSync(OutputDir).isDirectory();
 } catch { }
-if (!OutputDirIsDir) {
+if (OutputDirIsDir) {
     OutputDir += OutputDir.endsWith("/") ? "" : "/"
     CreateOutputDirectory(OutputDir);
 }


### PR DESCRIPTION
In this code snippet:
```javascript
let OutputDir = getRunnerInput('output_dir', 'built', getRunnerPath);
let OutputDirIsDir = false
try {
    OutputDirIsDir = fs.lstatSync(OutputDir).isDirectory();
} catch { }
if (!OutputDirIsDir) {
    OutputDir += OutputDir.endsWith("/") ? "" : "/"
    CreateOutputDirectory(OutputDir);
}
```
The current logic is - if the output directory is not a directory, then ensure it ends with a slash.
The logic should be - if the output directory is a directory, then ensure it ends with a slash.