### PR TITLE
Support Apple Silicon locally, and test there's no regression

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,11 +5,15 @@ on:
   pull_request:
   
 jobs:
-  test:
+  test-build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - run: docker build . -t markdown-to-pdf-from-ubuntu-latest
+  test-usage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
       - uses: ./
         with:
           input_path: README.md

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,3 +10,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: docker build . -t markdown-to-pdf-from-ubuntu-latest
+      - uses: ./
+        with:
+          input_path: README.md
+          output_dir: generated
+          build_html: false
+      - uses: actions/upload-artifact@v3
+        with:
+          name: readme
+          path: generated

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,12 @@
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: docker build . -t markdown-to-pdf-from-ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: docker build . -t markdown-to-pdf-from-ubuntu-latest
+      - run: docker build .
   test-usage:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
           input_path: README.md
           output_dir: generated
           build_html: false
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: readme
           path: generated

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18
+FROM --platform=linux/amd64 node:18
 
 RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
     sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' && \


### PR DESCRIPTION
This PR:

- [x] allows the Docker image to build on Apple Silicon locally by making `amd64` explicit (there might be another way to do this than the way I've chosen, so you're welcome to change it)
- [x] adds a `test.yml` to build the GitHub Action, and then use it to turn the readme into a PDF, including during a pull request.  This doesn't test the Apple Silicon compatibility; it just tests that I haven't introduced a regression, and it also might be useful for future pull requests

Testing the build in Apple Silicon on GitHub Actions has not been implemented, because I don't have the time to implement Docker setup in `macos-latest`, if this is even possible. In any case, it still won't allow the action to be _used_ in GitHub Actions on `macos-latest`, as observed by #52.  This is all just to make local usage easier.

### Motivation

1. On Apple Silicon locally, [nektos/act](https://github.com/nektos/act) fails to run a job which uses `markdown-to-pdf`, with or without a flag forcing it into `amd64` mode:
    ```console
    $ brew install act
    $ act --platform=linux/amd64
    
    [build.yml/pdf           ]   ❌  Failure - Main BaileyJM02/markdown-to-pdf@v1.2.0
    [build.yml/pdf           ] The command '/bin/sh -c wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - &&  ... (etc) ... && rm -rf /var/lib/apt/lists/*' returned a non-zero code: 100
    ```
1. `markdown-to-pdf` also fails to build locally.